### PR TITLE
Highlight Explorer toggle when panel visible

### DIFF
--- a/src/components/IDETab.jsx
+++ b/src/components/IDETab.jsx
@@ -2703,7 +2703,12 @@ main();`;
             </button>
             <button
               onClick={toggleExplorer}
-              className="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 p-2 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors flex items-center"
+              aria-pressed={isExplorerVisible}
+              className={`p-2 rounded transition-colors flex items-center ${
+                isExplorerVisible
+                  ? "bg-blue-500 text-white hover:bg-blue-600"
+                  : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600"
+              }`}
               title="Toggle Explorer (Ctrl+B)"
             >
               <Bars3Icon className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- Highlight the explorer toggle button when the file explorer is visible

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f94f1ae883298bfb4bf331f6bc62